### PR TITLE
Handle unpublishing of non-existing publish.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-dataspace/reference-provider
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/alecthomas/kong v0.9.0

--- a/internal/fsprovider/provider.go
+++ b/internal/fsprovider/provider.go
@@ -205,7 +205,9 @@ func (s *Server) UnpublishDataset(
 	}
 	pi := s.registry.GetByUUID(pID)
 	if pi == nil {
-		return nil, status.Errorf(codes.NotFound, "non-existent published set")
+		return &providerv1.UnpublishDatasetResponse{
+			Success: true,
+		}, nil
 	}
 	prefix := authprocessor.ExtractPrefix(ctx)
 	if !strings.HasPrefix(pi.File.FullPath, prefix) {

--- a/internal/fsprovider/provider.go
+++ b/internal/fsprovider/provider.go
@@ -204,6 +204,9 @@ func (s *Server) UnpublishDataset(
 		return nil, fmt.Errorf("invalid publish UUID: %w", err)
 	}
 	pi := s.registry.GetByUUID(pID)
+	if pi == nil {
+		return nil, status.Errorf(codes.NotFound, "non-existent published set")
+	}
 	prefix := authprocessor.ExtractPrefix(ctx)
 	if !strings.HasPrefix(pi.File.FullPath, prefix) {
 		return nil, status.Errorf(codes.PermissionDenied, "not allowed to access dataset")


### PR DESCRIPTION
When trying to unpublish a non-existing publish, a null pointer
error appeared. This fixes that and returns a not found error.