### PR TITLE
Support gRPC provider bindings v0.0.3-alpha1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kong v0.9.0
 	github.com/gabriel-vasile/mimetype v1.4.4
 	github.com/go-dataspace/run-dsp v0.0.0-20240701094331-999da6d03b65
-	github.com/go-dataspace/run-dsrpc v0.0.2-alpha1
+	github.com/go-dataspace/run-dsrpc v0.0.3-alpha1
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0
 	google.golang.org/grpc v1.64.1

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/go-dataspace/run-dsrpc v0.0.1-alpha1 h1:5AidaX66NMAjjVGjKRm/DMEw+xEyS
 github.com/go-dataspace/run-dsrpc v0.0.1-alpha1/go.mod h1:GS4hV6keaQWCn9KTwMqNgzOdIgPnJ/+NSHSvgrsLbTE=
 github.com/go-dataspace/run-dsrpc v0.0.2-alpha1 h1:MMOqPIMZ0Qwor8EQAsLJVQsE46//8zZP0uxz6jh5LWY=
 github.com/go-dataspace/run-dsrpc v0.0.2-alpha1/go.mod h1:GS4hV6keaQWCn9KTwMqNgzOdIgPnJ/+NSHSvgrsLbTE=
+github.com/go-dataspace/run-dsrpc v0.0.3-alpha1 h1:YvzHkw7ew+A7NMxOfwD6jOQ5Ki49BvKmzDhohzyYNPQ=
+github.com/go-dataspace/run-dsrpc v0.0.3-alpha1/go.mod h1:GS4hV6keaQWCn9KTwMqNgzOdIgPnJ/+NSHSvgrsLbTE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
This adds support for the aforementioned bindings and starts using
the fields that are relevant to the reference provider.